### PR TITLE
ISSUE-#27 APIのエラー処理追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "axios": "^1.2.2",
+    "fp-ts": "^2.13.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/components/container/models/trend.ts
+++ b/src/components/container/models/trend.ts
@@ -18,6 +18,29 @@ export class TrendSummary {
   }
 }
 
+export interface ErrorResponse {
+  get message(): string | undefined;
+}
+
+export class SystemError implements ErrorResponse {
+  constructor(private readonly _message: string | undefined) {}
+
+  get message(): string | undefined {
+    return this._message;
+  }
+}
+
+export class DomainError implements ErrorResponse {
+  constructor(
+    private readonly _message: string,
+    private readonly _requestID: string,
+  ) {}
+
+  get message(): string {
+    return `${this._message}, Request ID: ${this._requestID}`;
+  }
+}
+
 export interface TrendClient {
   indexSummary(endpoint: string): Promise<TrendSummary[]>;
 }

--- a/src/components/container/models/trend.ts
+++ b/src/components/container/models/trend.ts
@@ -1,3 +1,5 @@
+import { Either } from 'fp-ts/lib/Either';
+
 export class TrendSummary {
   constructor(
     private readonly _id: number,
@@ -42,5 +44,7 @@ export class DomainError implements ErrorResponse {
 }
 
 export interface TrendClient {
-  indexSummary(endpoint: string): Promise<TrendSummary[]>;
+  indexSummary(
+    endpoint: string,
+  ): Promise<Either<ErrorResponse, TrendSummary[]>>;
 }

--- a/src/components/container/repositories/api/trend.ts
+++ b/src/components/container/repositories/api/trend.ts
@@ -1,5 +1,11 @@
-import { TrendClient, TrendSummary } from 'components/container/models/trend';
-import axios, { AxiosInstance } from 'axios';
+import {
+  DomainError,
+  ErrorResponse,
+  SystemError,
+  TrendClient,
+  TrendSummary,
+} from 'components/container/models/trend';
+import axios, { AxiosError, AxiosInstance } from 'axios';
 import { singleton } from 'tsyringe';
 import { Either, left, right } from 'fp-ts/lib/Either';
 
@@ -12,6 +18,20 @@ class TrendAPIClient implements TrendClient {
       baseURL: `http://localhost:8000`,
       timeout: 15000,
     });
+
+    // インスタンス初期化時にインターセプター処理を渡せなさそう
+    this._cli.interceptors.response.use(
+      (response) => response,
+      (e: AxiosError<APIErrorResponse>) =>
+        Promise.reject(
+          e.response
+            ? new DomainError(
+                e.response.data.message,
+                e.response.data.request_id,
+              )
+            : new SystemError(e.message),
+        ),
+    );
   }
 
   indexSummary(

--- a/src/components/container/services/trend.ts
+++ b/src/components/container/services/trend.ts
@@ -1,12 +1,19 @@
 import { injectable, inject, singleton } from 'tsyringe';
-import { TrendClient, TrendSummary } from 'components/container/models/trend';
+import {
+  ErrorResponse,
+  TrendClient,
+  TrendSummary,
+} from 'components/container/models/trend';
+import { Either } from 'fp-ts/lib/Either';
 
 @singleton()
 @injectable()
 class TrendService {
   constructor(@inject('TrendClient') private client: TrendClient) {}
 
-  indexSummary(endpoint: string): Promise<TrendSummary[]> {
+  indexSummary(
+    endpoint: string,
+  ): Promise<Either<ErrorResponse, TrendSummary[]>> {
     return this.client.indexSummary(endpoint);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,6 +4895,11 @@ forwarded@0.2.0:
   resolved "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
+fp-ts@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.13.1.tgz#1bf2b24136cca154846af16752dc29e8fa506f2a"
+  integrity sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ==
+
 fraction.js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz"


### PR DESCRIPTION
1. エラーモデルのインターフェース・クラスを追加
2. APIレスポンスをEitherで返却するように修正
3. APIレスポンスのエラーをインターセプトしてエラーモデルに詰め替える処理を追加
4. エラー処理の場合にsnackbarで出力するようにコンポーネントを追加